### PR TITLE
Add cursor pagination for issues stream

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -842,6 +842,7 @@ class IssuesStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
+    use_cursor_paging = True
 
     def get_url_params(
         self,


### PR DESCRIPTION
To fix:

b'{"message":"Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before)","documentation_url":"https://docs.github.com/rest/issues/issues#list-repository-issues","status":"422"}' (Reason: Unprocessable Entity) for path: /repos/pulumi/pulumi-service/issues
